### PR TITLE
General Issue: Fix CI workflow and duplicate pipelines

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,10 @@
 name: EVA Open Targets pipelines
 
 on:
-  push:
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
 
 jobs:
   build:


### PR DESCRIPTION
This PR is a general fix for GitHub actions to stop having duplicate pipelines showing up in PRs. This was happening because we configure GitHub to run on both `a pull request` event and `push` event but this is unnecessary because when you push and then is an open PR it triggers the pull request event for CICD anyway. 

If you need to run the CICD with no pull request then I have added the ability to run the workflow manually. 

For more documentation regarding this matter you can follow that [link](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request). 