### PR TITLE
ISSUE-265 Integrate repeat expansion pipeline into main pipeline

### DIFF
--- a/consequence_prediction/repeat_expansion_variants/pipeline.py
+++ b/consequence_prediction/repeat_expansion_variants/pipeline.py
@@ -169,27 +169,27 @@ def determine_complete(row):
     return row
 
 
-def generate_output_files(variants, output_consequences, output_dataframe):
-    """Postprocess and output final tables."""
+def generate_consequences_file(consequences, output_consequences):
+    """Output final table."""
 
-    # Rearrange order of dataframe columns
-    variants = variants[
-        ['Name', 'RCVaccession', 'GeneSymbol', 'HGNC_ID',
-         'RepeatUnitLength', 'CoordinateSpan', 'IsProteinHGVS', 'TranscriptID',
-         'EnsemblGeneID', 'EnsemblGeneName', 'EnsemblChromosomeName', 'GeneAnnotationSource',
-         'RepeatType', 'RecordIsComplete']
-    ]
-    # Write the full dataframe. This is used for debugging and investigation purposes.
-    variants.sort_values(by=['Name', 'RCVaccession', 'GeneSymbol'])
-    variants.to_csv(output_dataframe, sep='\t', index=False)
+    if consequences.empty:
+        logger.info('There are no records ready for output')
+        return
+    # Write the consequences table. This is used by the main evidence string generation pipeline.
+    consequences.to_csv(output_consequences, sep='\t', index=False, header=False)
+    # Output statistics
+    logger.info(f'Generated {len(consequences)} consequences in total:')
+    logger.info(f'  {sum(consequences.RepeatType == "trinucleotide_repeat_expansion")} trinucleotide repeat expansion')
+    logger.info(f'  {sum(consequences.RepeatType == "short_tandem_repeat_expansion")} short tandem repeat expansion')
 
+
+def extract_consequences(variants):
     # Generate consequences table
     consequences = variants[variants['RecordIsComplete']] \
         .groupby(['RCVaccession', 'EnsemblGeneID', 'EnsemblGeneName'])['RepeatType'] \
         .apply(set).reset_index(name='RepeatType')
     if consequences.empty:
-        logger.info('There are no records ready for output')
-        return
+        return consequences
     # Check that for every (RCV, gene) pair there is only one consequence type
     assert consequences['RepeatType'].str.len().dropna().max() == 1, 'Multiple (RCV, gene) → variant type mappings!'
     # Get rid of sets
@@ -204,12 +204,20 @@ def generate_output_files(variants, output_consequences, output_dataframe):
     consequences.sort_values(by=['RepeatType', 'RCVaccession', 'EnsemblGeneID'], inplace=True)
     # Check that there are no empty cells in the final consequences table
     assert consequences.isnull().to_numpy().sum() == 0
-    # Write the consequences table. This is used by the main evidence string generation pipeline.
-    consequences.to_csv(output_consequences, sep='\t', index=False, header=False)
-    # Output statistics
-    logger.info(f'Generated {len(consequences)} consequences in total:')
-    logger.info(f'  {sum(consequences.RepeatType == "trinucleotide_repeat_expansion")} trinucleotide repeat expansion')
-    logger.info(f'  {sum(consequences.RepeatType == "short_tandem_repeat_expansion")} short tandem repeat expansion')
+    return consequences
+
+
+def generate_all_variants_file(output_dataframe, variants):
+    # Rearrange order of dataframe columns
+    variants = variants[
+        ['Name', 'RCVaccession', 'GeneSymbol', 'HGNC_ID',
+         'RepeatUnitLength', 'CoordinateSpan', 'IsProteinHGVS', 'TranscriptID',
+         'EnsemblGeneID', 'EnsemblGeneName', 'EnsemblChromosomeName', 'GeneAnnotationSource',
+         'RepeatType', 'RecordIsComplete']
+    ]
+    # Write the full dataframe. This is used for debugging and investigation purposes.
+    variants.sort_values(by=['Name', 'RCVaccession', 'GeneSymbol'])
+    variants.to_csv(output_dataframe, sep='\t', index=False)
 
 
 def main(clinvar_xml, output_consequences, output_dataframe):
@@ -239,7 +247,7 @@ def main(clinvar_xml, output_consequences, output_dataframe):
 
     if variants.empty:
         logger.info('No variants to process')
-        return
+        return None
 
     logger.info('Match each record to Ensembl gene ID and name')
     variants = annotate_ensembl_gene_info(variants)
@@ -248,6 +256,11 @@ def main(clinvar_xml, output_consequences, output_dataframe):
     variants = variants.apply(lambda row: determine_complete(row), axis=1)
 
     logger.info('Postprocess data and output the two final tables')
-    generate_output_files(variants, output_consequences, output_dataframe)
+    if output_dataframe is not None:
+        generate_all_variants_file(output_dataframe, variants)
+    consequences = extract_consequences(variants)
+    if output_consequences is not None:
+        generate_consequences_file(consequences, output_consequences)
 
     logger.info('Completed successfully')
+    return consequences

--- a/consequence_prediction/repeat_expansion_variants/pipeline.py
+++ b/consequence_prediction/repeat_expansion_variants/pipeline.py
@@ -220,7 +220,7 @@ def generate_all_variants_file(output_dataframe, variants):
     variants.to_csv(output_dataframe, sep='\t', index=False)
 
 
-def main(clinvar_xml, output_consequences, output_dataframe):
+def main(clinvar_xml, output_consequences=None, output_dataframe=None):
     """Process data and generate output files.
 
     Args:

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
@@ -8,6 +8,7 @@ from collections import defaultdict, Counter
 
 import jsonschema
 
+from consequence_prediction.repeat_expansion_variants import pipeline
 from eva_cttv_pipeline import clinvar_xml_utils
 from eva_cttv_pipeline.evidence_string_generation import consequence_type as CT
 
@@ -109,7 +110,8 @@ def validate_evidence_string(ev_string, ot_schema_contents):
 def launch_pipeline(clinvar_xml_file, efo_mapping_file, gene_mapping_file, ot_schema_file, dir_out):
     os.makedirs(dir_out, exist_ok=True)
     string_to_efo_mappings = load_efo_mapping(efo_mapping_file)
-    variant_to_gene_mappings = CT.process_consequence_type_file(gene_mapping_file)
+    repeat_expansion_consequences = pipeline.main(clinvar_xml_file, None, None)
+    variant_to_gene_mappings = CT.process_consequence_type_file(gene_mapping_file, CT.process_consequence_type_dataframe(repeat_expansion_consequences))
     report = clinvar_to_evidence_strings(
         string_to_efo_mappings, variant_to_gene_mappings, clinvar_xml_file, ot_schema_file,
         output_evidence_strings=os.path.join(dir_out, EVIDENCE_STRINGS_FILE_NAME))

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
@@ -110,7 +110,7 @@ def validate_evidence_string(ev_string, ot_schema_contents):
 def launch_pipeline(clinvar_xml_file, efo_mapping_file, gene_mapping_file, ot_schema_file, dir_out):
     os.makedirs(dir_out, exist_ok=True)
     string_to_efo_mappings = load_efo_mapping(efo_mapping_file)
-    repeat_expansion_consequences = pipeline.main(clinvar_xml_file, None, None)
+    repeat_expansion_consequences = pipeline.main(clinvar_xml_file)
     variant_to_gene_mappings = CT.process_consequence_type_file(gene_mapping_file, CT.process_consequence_type_dataframe(repeat_expansion_consequences))
     report = clinvar_to_evidence_strings(
         string_to_efo_mappings, variant_to_gene_mappings, clinvar_xml_file, ot_schema_file,

--- a/eva_cttv_pipeline/evidence_string_generation/consequence_type.py
+++ b/eva_cttv_pipeline/evidence_string_generation/consequence_type.py
@@ -36,14 +36,14 @@ def process_consequence_type_file_tsv(snp_2_gene_filepath, consequence_type_dict
 
 
 def process_consequence_type_dataframe(consequences_dataframe):
+    """
+    Return a dictionary of consequence information extracted from the dataframe
+    """
     consequence_type_dict = defaultdict(list)
-    for row in consequences_dataframe.itertuples:
+    for row in consequences_dataframe.itertuples():
         variant_id = row[0]
         ensembl_gene_id = row[2]
         so_term = row[4]
-
-        if pd.isna(ensembl_gene_id):
-            continue
 
         process_gene(consequence_type_dict, variant_id, ensembl_gene_id, so_term)
 
@@ -51,6 +51,10 @@ def process_consequence_type_dataframe(consequences_dataframe):
 
 
 def process_consequence_type_file(snp_2_gene_file, consequence_type_dict = None):
+    """
+        Return a dictionary of consequence information extracted from the given file.
+        If consequence_type_dict is provided then the information will be merge into this dictionary.
+    """
     logger.info('Loading mapping rs -> ENSG/SOterms')
     consequence_type_dict = process_consequence_type_file_tsv(snp_2_gene_file, consequence_type_dict)
     logger.info('{} rs->ENSG/SOterms mappings loaded'.format(len(consequence_type_dict)))

--- a/tests/eva_cttv_pipeline/evidence_string_generation/test_consequence_type.py
+++ b/tests/eva_cttv_pipeline/evidence_string_generation/test_consequence_type.py
@@ -21,7 +21,7 @@ class TestProcessGene:
 class TestProcessConsequenceTypeFileTsv:
     def test__process_consequence_type_file_tsv(self):
         test_consequence_type = CT.ConsequenceType("ENSG00000139988", CT.SoTerm("synonymous_variant"))
-        consequence_type_dict, one_rs_multiple_genes = CT.process_consequence_type_file_tsv(config.snp_2_gene_file)
+        consequence_type_dict = CT.process_consequence_type_file_tsv(config.snp_2_gene_file)
         assert consequence_type_dict["14:67729241:C:T"][0] == test_consequence_type
 
 


### PR DESCRIPTION
Refactor repeat expansion pipeline so that we can use it in order pipelines without making files, then call it from the main pipeline so it is not run as a separate step any more.

It closes #265 